### PR TITLE
fix the order of the arguments

### DIFF
--- a/python/spot/websocket.py
+++ b/python/spot/websocket.py
@@ -13,7 +13,7 @@ async def connect_forever():
     url = BTSE_WSEndpoint + path
     async with websockets.connect(url) as websocket:
         # Authentication
-        auth_payload = json.dumps(gen_auth(keypair['API-PASSPHRASE'], keypair['API-KEY']))
+        auth_payload = json.dumps(gen_auth(keypair['API-KEY'], keypair['API-PASSPHRASE']))
         await websocket.send(auth_payload)
 
         # Subscription


### PR DESCRIPTION
The `gen_auth(..)` takes the `api_key` and then the `secret_key` so the order used here needs to be flipped.