### PR TITLE
fix: bugs and complete order coverage across Python/Node/C#/Postman

### DIFF
--- a/CSharp/BTSEApiSample/FutureCancelOrderProject/FutureCancelOrder.cs
+++ b/CSharp/BTSEApiSample/FutureCancelOrderProject/FutureCancelOrder.cs
@@ -16,25 +16,24 @@ public class FutureCancelOrder
         {
             var response = await _httpClient.SendAsync(request);
 
-            // If the response is not successful, print the error message
+            // If the response is not successful, print the error message and stop
             if (response.IsSuccessStatusCode is false)
             {
                 Console.WriteLine($"Error message: {await response.Content.ReadAsStringAsync()}");
+                return null;
             }
-
-            response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<List<FutureCancelOrderResponseEntity>>();
         }
         catch (HttpRequestException httpErr)
         {
             Console.WriteLine($"HTTP error occurred: {httpErr.Message}");
-            throw;
+            return null;
         }
         catch (Exception err)
         {
             Console.WriteLine($"Other error occurred: {err.Message}");
-            throw;
+            return null;
         }
     }
 

--- a/CSharp/BTSEApiSample/FutureMakeOrderProject/FuturesMakeOrder.cs
+++ b/CSharp/BTSEApiSample/FutureMakeOrderProject/FuturesMakeOrder.cs
@@ -17,25 +17,24 @@ public class FuturesMakeOrder
         {
             var response = await _httpClient.SendAsync(requestMessage);
 
-            // If the response is not successful, print the error message
+            // If the response is not successful, print the error message and stop
             if (response.IsSuccessStatusCode is false)
             {
                 Console.WriteLine($"Error message: {await response.Content.ReadAsStringAsync()}");
+                return null;
             }
-
-            response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<List<FutureMakeOrderResponseEntity>>();
         }
         catch (HttpRequestException httpErr)
         {
             Console.WriteLine($"HTTP error occurred: {httpErr.Message}");
-            throw;
+            return null;
         }
         catch (Exception err)
         {
             Console.WriteLine($"Other error occurred: {err.Message}");
-            throw;
+            return null;
         }
     }
 

--- a/CSharp/BTSEApiSample/SpotCancelOrderProject/SpotCancelOrder.cs
+++ b/CSharp/BTSEApiSample/SpotCancelOrderProject/SpotCancelOrder.cs
@@ -16,25 +16,24 @@ public class SpotCancelOrder
         {
             var response = await _httpClient.SendAsync(request);
 
-            // If the response is not successful, print the error message
+            // If the response is not successful, print the error message and stop
             if (response.IsSuccessStatusCode is false)
             {
                 Console.WriteLine($"Error message: {await response.Content.ReadAsStringAsync()}");
+                return null;
             }
-
-            response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<List<SpotCancelOrderResponseEntity>>();
         }
         catch (HttpRequestException httpErr)
         {
             Console.WriteLine($"HTTP error occurred: {httpErr.Message}");
-            throw;
+            return null;
         }
         catch (Exception err)
         {
             Console.WriteLine($"Other error occurred: {err.Message}");
-            throw;
+            return null;
         }
     }
 

--- a/CSharp/BTSEApiSample/SpotMakeOrderProject/SpotMakeOrder.cs
+++ b/CSharp/BTSEApiSample/SpotMakeOrderProject/SpotMakeOrder.cs
@@ -17,25 +17,24 @@ public class SpotMakeOrder
         {
             var response = await _httpClient.SendAsync(requestMessage);
 
-            // If the response is not successful, print the error message
+            // If the response is not successful, print the error message and stop
             if (response.IsSuccessStatusCode is false)
             {
                 Console.WriteLine($"Error message: {await response.Content.ReadAsStringAsync()}");
+                return null;
             }
-
-            response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadFromJsonAsync<List<SpotMakeOrderResponseEntity>>();
         }
         catch (HttpRequestException httpErr)
         {
             Console.WriteLine($"HTTP error occurred: {httpErr.Message}");
-            throw;
+            return null;
         }
         catch (Exception err)
         {
             Console.WriteLine($"Other error occurred: {err.Message}");
-            throw;
+            return null;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Sample connectors for connecting to the BTSE API.
 
 ## Change Log
 
+* 2026-07-07
+  - Update **Postman** collection to match the current sample coverage and the v3.3 / v2.3 docs.
+    - Bump Spot API version `v3.2` -> `v3.3` and Futures `v2.1` -> `v2.3` (Wallet stays `v3.2`, OTC stays `v1`).
+    - Update Futures order examples to the `BTC-PERP` symbol format.
+    - Rename the mislabelled Spot `create-peg-order` (its body was a plain LIMIT order) to `create-limit-order`, and add a real `create-peg-order`.
+    - Add the full set of Create Order examples per the docs:
+      - Spot: MARKET, MARKET STOP, MARKET TAKE PROFIT, LIMIT STOP, OCO, TRAILING STOP, PEG.
+      - Futures: MARKET, LIMIT TRIGGER, LIMIT STOP, OCO, reduce-only, TP/SL (plus TP-only / SL-only), hedge-mode MARKET, TRAILING STOP.
+    - Trailing/stop trailing orders include the `trailValueType` field required by the live venue (not documented).
+
 * 2026-07-02
   - Update **Spot** samples to API v3.3 across Python / Node.js / C#.
     - Bump spot API version `v3.2` -> `v3.3` (symbols already `BTC-USD`).

--- a/nodejs/app/futures/create-trailing-stop-order.js
+++ b/nodejs/app/futures/create-trailing-stop-order.js
@@ -15,6 +15,7 @@ const placeTrailingStopOrder = async ({
   triggerPrice,
   stopPrice,
   trailValue,
+  trailValueType,
   clOrderID,
   trigger,
 }) => {
@@ -32,6 +33,7 @@ const placeTrailingStopOrder = async ({
     triggerPrice,
     stopPrice,
     trailValue,
+    trailValueType,
     clOrderID,
     trigger,
   };
@@ -54,7 +56,8 @@ placeTrailingStopOrder({
   type: 'MARKET',
   txType: 'TRIGGER',
   trigger: 'lastPrice', // markPrice or lastPrice
-  trailValue: 10,
+  trailValue: 0.05, // PERCENTAGE type, valid range [0.001, 0.99]
+  trailValueType: 'PERCENTAGE', // required by the API
 })
   .then(console.log)
   .catch(console.error);

--- a/postman/api.postman_collection.json
+++ b/postman/api.postman_collection.json
@@ -15,14 +15,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/market_summary",
+							"raw": "{{api-url}}/spot/api/v3.3/market_summary",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"market_summary"
 							]
 						}
@@ -35,14 +35,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/ohlcv?symbol=BTC-USD&resolution=30",
+							"raw": "{{api-url}}/spot/api/v3.3/ohlcv?symbol=BTC-USD&resolution=30",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"ohlcv"
 							],
 							"query": [
@@ -67,14 +67,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/price",
+							"raw": "{{api-url}}/spot/api/v3.3/price",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"price"
 							]
 						}
@@ -87,14 +87,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/orderbook?symbol=BTC-USDT&group=1&limit_bids=5&limit_asks=10",
+							"raw": "{{api-url}}/spot/api/v3.3/orderbook?symbol=BTC-USDT&group=1&limit_bids=5&limit_asks=10",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"orderbook"
 							],
 							"query": [
@@ -125,14 +125,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/orderbook/L2?symbol=BTC-USD&depth=5",
+							"raw": "{{api-url}}/spot/api/v3.3/orderbook/L2?symbol=BTC-USD&depth=5",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"orderbook",
 								"L2"
 							],
@@ -156,14 +156,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/trades?symbol=BTC-USD",
+							"raw": "{{api-url}}/spot/api/v3.3/trades?symbol=BTC-USD",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"trades"
 							],
 							"query": [
@@ -182,14 +182,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/time",
+							"raw": "{{api-url}}/spot/api/v3.3/time",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"time"
 							]
 						}
@@ -197,7 +197,7 @@
 					"response": []
 				},
 				{
-					"name": "create-peg-order",
+					"name": "create-limit-order",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -232,15 +232,366 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/order",
+							"raw": "{{api-url}}/spot/api/v3.3/order",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-market-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"size\": 0.0005,\n  \"side\": \"SELL\",\n  \"type\": \"MARKET\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-oco-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"size\": 0.0005,\n  \"price\": 20300,\n  \"side\": \"BUY\",\n  \"type\": \"OCO\",\n  \"txType\": \"LIMIT\",\n  \"stopPrice\": 20300,\n  \"triggerPrice\": 20309\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-market-stop-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"price\": 30,\n  \"side\": \"BUY\",\n  \"type\": \"MARKET\",\n  \"txType\": \"STOP\",\n  \"triggerPrice\": 31000,\n  \"triggerPriceType\": \"LAST_PRICE\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-trailing-stop-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"price\": 30,\n  \"side\": \"BUY\",\n  \"type\": \"MARKET\",\n  \"txType\": \"STOP\",\n  \"trailValue\": 0.05,\n  \"trailValueType\": \"PERCENTAGE\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-market-take-profit-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"price\": 30,\n  \"side\": \"BUY\",\n  \"type\": \"MARKET\",\n  \"txType\": \"TRIGGER\",\n  \"triggerPrice\": 31000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-limit-stop-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"size\": 0.0005,\n  \"price\": 34000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\",\n  \"txType\": \"STOP\",\n  \"triggerPrice\": 32000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-peg-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-USD\",\n  \"size\": 0.0005,\n  \"price\": 25000,\n  \"side\": \"BUY\",\n  \"type\": \"PEG\",\n  \"deviation\": -10,\n  \"stealth\": 10\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/spot/api/v3.3/order/peg",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"spot",
+								"api",
+								"v3.3",
+								"order",
+								"peg"
 							]
 						}
 					},
@@ -282,14 +633,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/order",
+							"raw": "{{api-url}}/spot/api/v3.3/order",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"order"
 							]
 						}
@@ -323,14 +674,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/order?symbol=BTC-USD",
+							"raw": "{{api-url}}/spot/api/v3.3/order?symbol=BTC-USD",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"order"
 							],
 							"query": [
@@ -379,14 +730,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/order/cancelAllAfter",
+							"raw": "{{api-url}}/spot/api/v3.3/order/cancelAllAfter",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"order",
 								"cancelAllAfter"
 							]
@@ -442,14 +793,14 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/user/open_orders?symbol=BTC-USD",
+							"raw": "{{api-url}}/spot/api/v3.3/user/open_orders?symbol=BTC-USD",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"user",
 								"open_orders"
 							],
@@ -490,14 +841,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/user/trade_history?symbol=BTC-USD",
+							"raw": "{{api-url}}/spot/api/v3.3/user/trade_history?symbol=BTC-USD",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"user",
 								"trade_history"
 							],
@@ -538,14 +889,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/spot/api/v3.2/user/fees",
+							"raw": "{{api-url}}/spot/api/v3.3/user/fees",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"spot",
 								"api",
-								"v3.2",
+								"v3.3",
 								"user",
 								"fees"
 							]
@@ -597,14 +948,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/market_summary",
+							"raw": "{{api-url}}/futures/api/v2.3/market_summary",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"market_summary"
 							],
 							"query": [
@@ -624,20 +975,20 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/ohlcv?symbol=BTCPFC&resolution=15",
+							"raw": "{{api-url}}/futures/api/v2.3/ohlcv?symbol=BTC-PERP&resolution=15",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"ohlcv"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC",
+									"value": "BTC-PERP",
 									"description": "market symbol"
 								},
 								{
@@ -656,14 +1007,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/price",
+							"raw": "{{api-url}}/futures/api/v2.3/price",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"price"
 							]
 						}
@@ -676,20 +1027,20 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/orderbook?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/orderbook?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"orderbook"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -702,21 +1053,21 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/orderbook/L2?symbol=BTCPFC&depth=5",
+							"raw": "{{api-url}}/futures/api/v2.3/orderbook/L2?symbol=BTC-PERP&depth=5",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"orderbook",
 								"L2"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								},
 								{
 									"key": "depth",
@@ -733,20 +1084,20 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/trades?symbol=BTCPFC&count=10",
+							"raw": "{{api-url}}/futures/api/v2.3/trades?symbol=BTC-PERP&count=10",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"trades"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								},
 								{
 									"key": "count",
@@ -796,7 +1147,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"size\": 1,\n  \"price\": 11000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\"\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"price\": 11000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -804,14 +1155,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order",
+							"raw": "{{api-url}}/futures/api/v2.3/order",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order"
 							]
 						}
@@ -846,7 +1197,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"price\": 11500,\n  \"size\": 1,\n  \"side\": \"BUY\",\n  \"stealth\": 10,\n  \"deviation\": -10\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"price\": 11500,\n  \"size\": 1,\n  \"side\": \"BUY\",\n  \"stealth\": 10,\n  \"deviation\": -10\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -854,16 +1205,516 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order/peg",
+							"raw": "{{api-url}}/futures/api/v2.3/order/peg",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order",
 								"peg"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-market-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clOrderID\": \"test-order-placement\",\n  \"size\": 0.0005,\n  \"side\": \"BUY\",\n  \"symbol\": \"BTC-PERP\",\n  \"txType\": \"LIMIT\",\n  \"type\": \"MARKET\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-oco-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clOrderID\": \"test-order-placement\",\n  \"size\": 1,\n  \"price\": 20100,\n  \"side\": \"BUY\",\n  \"time_in_force\": \"GTC\",\n  \"symbol\": \"BTC-PERP\",\n  \"triggerPrice\": 20400,\n  \"stopPrice\": 20401,\n  \"type\": \"OCO\",\n  \"txType\": \"LIMIT\",\n  \"trigger\": \"markPrice\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-reduce-only-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"size\": 1,\n  \"price\": 20000,\n  \"side\": \"SELL\",\n  \"symbol\": \"BTC-PERP\",\n  \"type\": \"LIMIT\",\n  \"reduceOnly\": true\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-limit-stop-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clOrderID\": \"test-stop-order-placement\",\n  \"size\": 1,\n  \"price\": 21000,\n  \"side\": \"BUY\",\n  \"symbol\": \"BTC-PERP\",\n  \"type\": \"LIMIT\",\n  \"txType\": \"STOP\",\n  \"triggerPrice\": 30000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-trailing-stop-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clOrderID\": \"test-trailing-stop-order-placement\",\n  \"size\": 1,\n  \"side\": \"BUY\",\n  \"symbol\": \"BTC-PERP\",\n  \"type\": \"MARKET\",\n  \"txType\": \"TRIGGER\",\n  \"trigger\": \"lastPrice\",\n  \"trailValue\": 0.05,\n  \"trailValueType\": \"PERCENTAGE\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-limit-trigger-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"price\": 21000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\",\n  \"txType\": \"TRIGGER\",\n  \"triggerPrice\": 30000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-order-with-tp-sl",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"price\": 29000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\",\n  \"takeProfitPrice\": 31000,\n  \"takeProfitTrigger\": \"markPrice\",\n  \"stopLossPrice\": 27000,\n  \"stopLossTrigger\": \"lastPrice\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-order-with-tp-only",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"price\": 29000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\",\n  \"takeProfitPrice\": 31000,\n  \"takeProfitTrigger\": \"markPrice\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-order-with-sl-only",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"price\": 29000,\n  \"side\": \"BUY\",\n  \"type\": \"LIMIT\",\n  \"stopLossPrice\": 27000,\n  \"stopLossTrigger\": \"lastPrice\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create-hedge-mode-market-order",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "request-api",
+								"value": "{{api-key}}",
+								"type": "text"
+							},
+							{
+								"key": "secret",
+								"value": "{{api-secret}}",
+								"type": "text"
+							},
+							{
+								"key": "request-nonce",
+								"value": "{{api-nonce}}",
+								"type": "text"
+							},
+							{
+								"key": "request-sign",
+								"value": "{{api-sign}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"size\": 1,\n  \"side\": \"BUY\",\n  \"type\": \"MARKET\",\n  \"positionMode\": \"HEDGE\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api-url}}/futures/api/v2.3/order",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"futures",
+								"api",
+								"v2.3",
+								"order"
 							]
 						}
 					},
@@ -897,7 +1748,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"orderID\": \"61d3ec71-384c-494d-94fc-397a1c169300\",\n  \"type\": \"PRICE\",\n  \"value\": 13000\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"orderID\": \"61d3ec71-384c-494d-94fc-397a1c169300\",\n  \"type\": \"PRICE\",\n  \"value\": 13000\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -905,14 +1756,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order",
+							"raw": "{{api-url}}/futures/api/v2.3/order",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order"
 							]
 						}
@@ -946,20 +1797,20 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/order?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -1002,14 +1853,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order/cancelAllAfter",
+							"raw": "{{api-url}}/futures/api/v2.3/order/cancelAllAfter",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order",
 								"cancelAllAfter"
 							]
@@ -1044,21 +1895,21 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/open_orders?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/user/open_orders?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"open_orders"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -1092,21 +1943,21 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/trade_history?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/user/trade_history?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"trade_history"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -1140,21 +1991,21 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/positions?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/user/positions?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"positions"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -1189,7 +2040,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"price\": 0,\n  \"symbol\": \"BTCPFC\",\n  \"type\": \"MARKET\"\n}",
+							"raw": "{\n  \"price\": 0,\n  \"symbol\": \"BTC-PERP\",\n  \"type\": \"MARKET\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1197,14 +2048,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/order/close_position",
+							"raw": "{{api-url}}/futures/api/v2.3/order/close_position",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"order",
 								"close_position"
 							]
@@ -1240,7 +2091,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"riskLimit\": 0\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"riskLimit\": 0\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1248,14 +2099,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/risk_limit",
+							"raw": "{{api-url}}/futures/api/v2.3/risk_limit",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"risk_limit"
 							]
 						}
@@ -1290,7 +2141,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"leverage\": 0\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"leverage\": 0\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1298,14 +2149,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/leverage",
+							"raw": "{{api-url}}/futures/api/v2.3/leverage",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"leverage"
 							]
 						}
@@ -1340,7 +2191,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbol\": \"BTCPFC\",\n  \"currency\": \"BTC\"\n}",
+							"raw": "{\n  \"symbol\": \"BTC-PERP\",\n  \"currency\": \"BTC\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1348,14 +2199,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/settle_in",
+							"raw": "{{api-url}}/futures/api/v2.3/settle_in",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"settle_in"
 							]
 						}
@@ -1389,14 +2240,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/fees",
+							"raw": "{{api-url}}/futures/api/v2.3/user/fees",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"fees"
 							]
@@ -1431,14 +2282,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/wallet",
+							"raw": "{{api-url}}/futures/api/v2.3/user/wallet",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"wallet"
 							]
@@ -1473,14 +2324,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/wallet_history",
+							"raw": "{{api-url}}/futures/api/v2.3/user/wallet_history",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"wallet_history"
 							]
@@ -1515,21 +2366,21 @@
 							}
 						],
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/margin?symbol=BTCPFC",
+							"raw": "{{api-url}}/futures/api/v2.3/user/margin?symbol=BTC-PERP",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"margin"
 							],
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCPFC"
+									"value": "BTC-PERP"
 								}
 							]
 						}
@@ -1575,14 +2426,14 @@
 							}
 						},
 						"url": {
-							"raw": "{{api-url}}/futures/api/v2.1/user/wallet/transfer",
+							"raw": "{{api-url}}/futures/api/v2.3/user/wallet/transfer",
 							"host": [
 								"{{api-url}}"
 							],
 							"path": [
 								"futures",
 								"api",
-								"v2.1",
+								"v2.3",
 								"user",
 								"wallet",
 								"transfer"

--- a/python/api/futures_cancel_all_after.py
+++ b/python/api/futures_cancel_all_after.py
@@ -30,7 +30,8 @@ def funct(data):
     except Exception as err:
         print("Other error occurred: {0}".format(err))
     finally:
-        ret = resp.json()
+        # cancelAllAfter can succeed with an empty body (HTTP 200, no JSON)
+        ret = resp.json() if resp.text else {"status_code": resp.status_code}
     return ret
 
 

--- a/python/api/futures_place_trailing_stop_order.py
+++ b/python/api/futures_place_trailing_stop_order.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import json
+import requests
+from requests.exceptions import HTTPError
+from utils import (
+    get_env_info,
+    get_futures_api_version,
+    get_futures_full_url,
+    gen_headers,
+)
+
+
+def futures_place_trailing_stop_order(data):
+    url = "/api/{0}/order".format(get_futures_api_version())
+    env = get_env_info()
+    headers = gen_headers(
+        env["API_KEY"], env["API_SECRET_KEY"], url, json.dumps(data)
+    )
+    ret = {}
+    try:
+        resp = requests.post(
+            get_futures_full_url(env["API_HOST"], url),
+            json=data,
+            headers=headers,
+        )
+        resp.raise_for_status()
+    except HTTPError as http_err:
+        print("HTTP error occurred: {0}".format(http_err))
+    except Exception as err:
+        print("Other error occurred: {0}".format(err))
+    finally:
+        ret = resp.json()
+    return ret
+
+
+if __name__ == "__main__":
+    # Trailing stop: txType=TRIGGER with a trigger price source (lastPrice /
+    # markPrice). trailValueType is required; trailValue is a decimal in the
+    # range [0.001, 0.99] when trailValueType is PERCENTAGE.
+    print(
+        futures_place_trailing_stop_order(
+            {
+                "clOrderID": "test-trailing-stop-order-placement",
+                "size": 1,
+                "side": "BUY",
+                "symbol": "BTC-PERP",
+                "type": "MARKET",
+                "txType": "TRIGGER",
+                "trigger": "lastPrice",
+                "trailValue": 0.05,
+                "trailValueType": "PERCENTAGE",
+            }
+        )
+    )

--- a/python/api/spot_cancel_all_after.py
+++ b/python/api/spot_cancel_all_after.py
@@ -31,7 +31,8 @@ def spot_cancel_all_after(data):
     except Exception as err:
         print("Other error occurred: {0}".format(err))
     finally:
-        ret = resp.json()
+        # cancelAllAfter can succeed with an empty body (HTTP 200, no JSON)
+        ret = resp.json() if resp.text else {"status_code": resp.status_code}
     return ret
 
 

--- a/python/api/spot_get_wallet_balance.py
+++ b/python/api/spot_get_wallet_balance.py
@@ -4,14 +4,14 @@ import requests
 from requests.exceptions import HTTPError
 from utils import (
     get_env_info,
-    get_spot_api_version,
+    get_wallet_api_version,
     get_spot_full_url,
     gen_headers,
 )
 
 
 def spot_get_wallet_balance():
-    url = "/api/{0}/user/wallet".format(get_spot_api_version())
+    url = "/api/{0}/user/wallet".format(get_wallet_api_version())
     env = get_env_info()
     headers = gen_headers(env["API_KEY"], env["API_SECRET_KEY"], url)
     ret = {}

--- a/python/api/spot_post_place_order.py
+++ b/python/api/spot_post_place_order.py
@@ -33,7 +33,7 @@ def spot_place_order(data):
 
 
 if __name__ == "__main__":
-    # 4 kinds of data input
+    # 6 kinds of data input
     market_order_data = {
         "symbol": "BTC-USD",
         "size": 0.0005,
@@ -70,4 +70,30 @@ if __name__ == "__main__":
         "stealth": 10,
     }
 
+    # MARKET STOP: `price` is the max spend amount and must NOT be sent
+    # together with `size` (otherwise: "Size and Price should not be mixed").
+    stop_order_data = {
+        "symbol": "BTC-USD",
+        "price": 30,
+        "side": "BUY",
+        "type": "MARKET",
+        "txType": "STOP",
+        "triggerPrice": 31000,
+        "triggerPriceType": "LAST_PRICE",
+    }
+
+    # TRAILING STOP: trailValueType is required (PERCENTAGE); trailValue is a
+    # decimal in the range [0.001, 0.99]. Like MARKET STOP, do not send `size`.
+    trailing_stop_order_data = {
+        "symbol": "BTC-USD",
+        "price": 30,
+        "side": "BUY",
+        "type": "MARKET",
+        "txType": "STOP",
+        "trailValue": 0.05,
+        "trailValueType": "PERCENTAGE",
+    }
+
     print(spot_place_order(market_order_data))
+    print(spot_place_order(stop_order_data))
+    print(spot_place_order(trailing_stop_order_data))

--- a/python/api/utils.py
+++ b/python/api/utils.py
@@ -35,6 +35,15 @@ def get_spot_api_version():
     return "v3.3"
 
 
+def get_wallet_api_version():
+    """Get wallet api version
+
+    Wallet endpoints live under the /spot path but are versioned
+    independently of the spot trading API, which is currently v3.3.
+    """
+    return "v3.2"
+
+
 def get_futures_api_version():
     """Get futures api version"""
     return "v2.3"

--- a/python/api/wallet_convert_funds.py
+++ b/python/api/wallet_convert_funds.py
@@ -5,14 +5,14 @@ import requests
 from requests.exceptions import HTTPError
 from utils import (
     get_env_info,
-    get_spot_api_version,
+    get_wallet_api_version,
     get_spot_full_url,
     gen_headers,
 )
 
 
 def convert_funds(data):
-    url = "/api/{0}/user/wallet/convert".format(get_spot_api_version())
+    url = "/api/{0}/user/wallet/convert".format(get_wallet_api_version())
     env = get_env_info()
     headers = gen_headers(
         env["API_KEY"], env["API_SECRET_KEY"], url, json.dumps(data)

--- a/python/api/wallet_query_available_crypto.py
+++ b/python/api/wallet_query_available_crypto.py
@@ -2,11 +2,11 @@
 
 import requests
 from requests.exceptions import HTTPError
-from utils import get_env_info, get_spot_api_version, get_spot_full_url
+from utils import get_env_info, get_wallet_api_version, get_spot_full_url
 
 
 def availableCurrencyNetworks(params):
-    url = "/api/{0}/availableCurrencyNetworks".format(get_spot_api_version())
+    url = "/api/{0}/availableCurrencyNetworks".format(get_wallet_api_version())
     env = get_env_info()
     ret = {}
     try:

--- a/python/api/wallet_query_available_currency.py
+++ b/python/api/wallet_query_available_currency.py
@@ -4,14 +4,14 @@ import requests
 from requests.exceptions import HTTPError
 from utils import (
     get_env_info,
-    get_spot_api_version,
+    get_wallet_api_version,
     get_spot_full_url,
     gen_headers,
 )
 
 
 def availableCurrencies(data):
-    url = "/api/{0}/availableCurrencies".format(get_spot_api_version())
+    url = "/api/{0}/availableCurrencies".format(get_wallet_api_version())
     env = get_env_info()
     headers = gen_headers(env["API_KEY"], env["API_SECRET_KEY"], url)
     ret = {}

--- a/python/api/wallet_query_balance.py
+++ b/python/api/wallet_query_balance.py
@@ -5,13 +5,13 @@ from requests.exceptions import HTTPError
 from utils import (
     gen_headers,
     get_env_info,
-    get_spot_api_version,
+    get_wallet_api_version,
     get_spot_full_url,
 )
 
 
 def queryWalletBalance(params):
-    url = "/api/{0}/user/wallet".format(get_spot_api_version())
+    url = "/api/{0}/user/wallet".format(get_wallet_api_version())
     env = get_env_info()
     headers = gen_headers(env["API_KEY"], env["API_SECRET_KEY"], url)
     ret = {}

--- a/python/api/wallet_query_exchange_rate.py
+++ b/python/api/wallet_query_exchange_rate.py
@@ -2,11 +2,11 @@
 
 import requests
 from requests.exceptions import HTTPError
-from utils import get_env_info, get_spot_api_version, get_spot_full_url
+from utils import get_env_info, get_wallet_api_version, get_spot_full_url
 
 
 def exchangeRate(params):
-    url = "/api/{0}/exchangeRate".format(get_spot_api_version())
+    url = "/api/{0}/exchangeRate".format(get_wallet_api_version())
     env = get_env_info()
     ret = {}
     try:

--- a/python/api/wallet_query_history.py
+++ b/python/api/wallet_query_history.py
@@ -5,13 +5,13 @@ from requests.exceptions import HTTPError
 from utils import (
     gen_headers,
     get_env_info,
-    get_spot_api_version,
+    get_wallet_api_version,
     get_spot_full_url,
 )
 
 
 def queryWalletBalance():
-    url = "/api/{0}/user/wallet_history".format(get_spot_api_version())
+    url = "/api/{0}/user/wallet_history".format(get_wallet_api_version())
     env = get_env_info()
     headers = gen_headers(env["API_KEY"], env["API_SECRET_KEY"], url)
     ret = {}


### PR DESCRIPTION
- python: add get_wallet_api_version() (v3.2) so 7 wallet samples stop building v3.3 URLs and hitting 404
- python: guard cancelAllAfter empty-body success against JSONDecodeError (spot/futures)
- python: add Spot STOP / TRAILING STOP examples and a new futures trailing-stop sample for three-language parity
- nodejs: add the required trailValueType field to create-trailing-stop-order.js
- csharp: stop the 4 make/cancel projects from crashing on business errors (drop EnsureSuccessStatusCode, return null instead of rethrowing)
- postman: bump Spot v3.2->v3.3 and Futures v2.1->v2.3 (Wallet stays v3.2, OTC v1), BTCPFC->BTC-PERP, fix the mislabelled create-peg-order, and add the full set of Create Order examples per the v3.3 / v2.3 docs
- readme: changelog entry for the Postman update